### PR TITLE
Fixed kernel card colors in dark theme

### DIFF
--- a/style/index.css
+++ b/style/index.css
@@ -44,6 +44,11 @@ div.card{
 .ksmm-kernel-cards {
     width: 12rem;
     min-height: 12rem;
+    background: var(--jp-layout-color1);
+}
+
+.ksmm-kernel-cards .card-header {
+    background: var(--jp-layout-color2);
 }
 
 .ksmm-pointer {

--- a/style/index.css
+++ b/style/index.css
@@ -14,7 +14,7 @@
 }
 
 .ksmm-button-enabled {
-    color: var(--jp-brand-color1);;
+    color: var(--jp-brand-color1);
 }
 
 div.card{
@@ -38,17 +38,19 @@ div.card{
     margin-top: 1rem;
     margin-bottom: 1rem;
     border: 0;
-    border-top: 1px solid rgba(0,0,0,.1);
+    border-top: 1px solid var(--jp-layout-color3);
 }
 
 .ksmm-kernel-cards {
     width: 12rem;
     min-height: 12rem;
     background: var(--jp-layout-color1);
+    border: 1px solid var(--jp-layout-color3);
 }
 
 .ksmm-kernel-cards .card-header {
     background: var(--jp-layout-color2);
+    border-bottom: 1px solid var(--jp-layout-color3);
 }
 
 .ksmm-pointer {


### PR DESCRIPTION
This PR fixes the background and border colors for kernal cards and their headers in dark themes.
- Sets background color as it was getting picked from the imported card class from bootstrap and not the page's background color.
- Sets header background color using JupyterLab theme color variable which was earlier set by bootstrap card CSS using opacity which doesn't work well with dark themes.
- Sets card border and kernels separator line colors using JupyterLab theme color variable.