### PR TITLE
Fixed css bug in card colors and bumped version to 0.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [0.1.6](https://github.com/deshaw/ksmm/compare/v0.1.5...v0.1.6) (2022-08-10)
+## [0.1.6](https://github.com/deshaw/ksmm/compare/v0.1.5...v0.1.6) (2022-08-16)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [0.1.6](https://github.com/deshaw/ksmm/compare/v0.1.5...v0.1.6) (2022-08-10)
+
+### Fixed
+
+- Kernel card colors in dark theme
+
 ## [0.1.5](https://github.com/deshaw/ksmm/compare/v0.1.4...v0.1.5) (2022-03-17)
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deshaw/jupyterlab-ksmm",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "An extension to manage Kernelspecs from JupyterLab",
   "keywords": [
     "jupyter",

--- a/style/index.css
+++ b/style/index.css
@@ -44,8 +44,8 @@ div.card{
 .ksmm-kernel-cards {
     width: 12rem;
     min-height: 12rem;
-    background: var(--jp-layout-color1);
-    border: 1px solid var(--jp-layout-color3);
+    background: var(--jp-layout-color1) !important;
+    border: 1px solid var(--jp-layout-color3) !important;
 }
 
 .ksmm-kernel-cards .card-header {


### PR DESCRIPTION
Since we are overriding a few colors of extracted_bootstrap_styles.css in index.css, sometimes both the files are loaded in a different order which changes their priority order, hence the theme colors were not showing up.

Hence, we need to add `!important` to always override the colors with theme colors.