### PR TITLE
Try to fix wheel building.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,3 +52,4 @@ jobs:
         run: |
           jlpm
           python setup.py bdist_wheel sdist
+          python tools/verify_wheel.py

--- a/Makefile
+++ b/Makefile
@@ -72,10 +72,15 @@ main:
 	($(CONDA_ACTIVATE) ${ENV_NAME}; \
 		python -m ksmm )
 
-publish:
+build_release:
 	($(CONDA_ACTIVATE) ${ENV_NAME}; \
 		rm -fr dist/* && \
+		jlpm &&\
 		yarn clean && \
-		yarn build:prod && \
+		jlpm build:prod && \
 		python setup.py sdist bdist_wheel && \
+		ls -lh  dist/)
+
+publish: build_release
+	($(CONDA_ACTIVATE) ${ENV_NAME}; \
 		twine upload dist/* )

--- a/environment.yaml
+++ b/environment.yaml
@@ -5,7 +5,7 @@ dependencies:
   - jupyterlab
   - pip
   - psutil
-  - setuptools
+  - setuptools<61
   - tornado
   - twine
   - yarn

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@
 """
 
 import json
+import sys
 from pathlib import Path
 
 import setuptools
@@ -70,7 +71,13 @@ setup_args = dict(
     ],
 )
 
-try:
+editable_install = ('egg_info' in sys.argv) or ('dist_info' in sys.argv) or ('editable_wheel' in sys.argv)
+
+if editable_install:
+    print("It looks like you are doing an editable install. We won't try to build the js.")
+    print("If you are building a sdist or wheel, those may be corrupted.")
+else:
+
     from jupyter_packaging import wrap_installers, npm_builder, get_data_files
 
     post_develop = npm_builder(
@@ -80,8 +87,6 @@ try:
         post_develop=post_develop, ensured_targets=ensured_targets
     )
     setup_args["data_files"] = get_data_files(data_files_spec)
-except ImportError:
-    pass
 
 if __name__ == "__main__":
     setuptools.setup(**setup_args)

--- a/tools/verify_wheel.py
+++ b/tools/verify_wheel.py
@@ -1,0 +1,26 @@
+from glob import glob
+from zipfile import ZipFile
+import sys
+
+
+wheel_list = glob('dist/*.whl')
+
+if not wheel_list:
+    sys.exist('No wheel found')
+
+
+for wheel_file in wheel_list:
+    z = ZipFile(wheel_file)
+    filenames = [f.filename for f  in z.filelist]
+    statics = [f for f in filenames if 'labextension/static' in f]
+    if len(statics) < 20:
+        sys.exit(f"less static file than expected in wheel  {len(statics)}/20")
+    labex = [f for f in filenames if 'labextensions/@deshaw/jupyterlab-ksmm' in f]
+    if len(labex) < 22:
+        sys.exit(f"less labextension files file than expected in wheel  {len(static)}/22")
+print('ok')
+
+
+
+
+


### PR DESCRIPTION
It looks like the sdist/wheel can be build without the js if the js is
built in the wrong location.

This should fix that by making sure that:

- wheel building fails if we can't import jupyter_packaging instead of
  silently continuing.
- Still allow to not have jupyter_packaging when using an editable
  install.

It also adds a verification tools for the wheel, and pin setuptools