### PR TITLE
bump to version 0.1.8 and publish.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,8 +79,10 @@ build_release:
 		yarn clean && \
 		jlpm build:prod && \
 		python setup.py sdist bdist_wheel && \
+		python tools/verify_wheel.py && \
 		ls -lh  dist/)
 
 publish: build_release
 	($(CONDA_ACTIVATE) ${ENV_NAME}; \
+		python tools/verify_wheel.py && \
 		twine upload dist/* )

--- a/README.md
+++ b/README.md
@@ -186,7 +186,13 @@ To publish a release, you need to manually bump the version number of the [packa
 
 Pleas follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) rules when bumping the version number.
 
-Commmit and push your changes, then run the following comamand which clean, build and push the needed artifact into the [PyPi Ksmm project](https://pypi.org/project/ksmm) (ensure you have been given the needed authorization for that).
+Commit and push your changes, then run the following command which clean, build and push the needed artifact into the [PyPi Ksmm project](https://pypi.org/project/ksmm) (ensure you have been given the needed authorization for that).
+```
+make build_release
+twine upload dist/*
+```
+
+Or simply
 
 ```bash
 make publish

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deshaw/jupyterlab-ksmm",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "An extension to manage Kernelspecs from JupyterLab",
   "keywords": [
     "jupyter",


### PR DESCRIPTION
This is the commit that was released a few minutes ago as 0.1.8.

I do not have the right permission on this repo so it would be good to in addition to merge, tag it as 0.1.8.