### PR TITLE
Add a dependabot configuration for keeping actions up to date

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+# Set update schedule for GitHub Actions
+
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every week
+      interval: "weekly"


### PR DESCRIPTION
This PR adds a dependabot configuration to keep github actions up to date. It will run a check once a week to automatically create a PR to update an action if an action has a new version available.

To enable this, you'll need to go into the `Security -> Code Security` settings for the repository and click the `Enable` button next to `Dependabot version updates`. This should also activate the `Dependabot on Actions runners` button as well.

![enable](https://github.com/user-attachments/assets/44ea0ef3-e147-47f5-afd3-a27f9276b3b0)

After testing on my fork, it looks like this will generate 4 PRs right away for various actions.